### PR TITLE
Add view_msgs/view_threads, fix batch IDs, improve repr and html cleaning

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: New Features
+      labels: [enhancement]
+    - title: Bug Fixes
+      labels: [bug]
+    - title: Breaking Changes
+      labels: [breaking]


### PR DESCRIPTION
## Summary
- Add `view_msgs` and `view_threads` methods to Gmail class for batch fetching summaries
- Fix `_batch_get` request ID conflicts using uuid
- Update `Msg.__repr__` and `Thread.__repr__` to show labels
- Improve `Msg.html` to preserve forwarded content (only remove quotes after non-quote content)
- Add `.github/release.yml` for auto-generated release notes